### PR TITLE
Add `build-essential` to apt command for Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ OSX Sierra titlebar buttons.
 There are some dependencies you'll need to install. Some people suggested using the following commands:
 ### Ubuntu
 ``` shell
-sudo apt install libkf5config-dev libkdecorations2-dev libqt5x11extras5-dev qtdeclarative5-dev extra-cmake-modules libkf5guiaddons-dev libkf5configwidgets-dev libkf5windowsystem-dev libkf5coreaddons-dev gettext
+sudo apt install build-essential libkf5config-dev libkdecorations2-dev libqt5x11extras5-dev qtdeclarative5-dev extra-cmake-modules libkf5guiaddons-dev libkf5configwidgets-dev libkf5windowsystem-dev libkf5coreaddons-dev gettext
 ```
 
 ### Arch Linux


### PR DESCRIPTION
Ubuntu and its derivatives might not include a compiler by default. Installing the [`build-essential`](https://packages.ubuntu.com/bionic/build-essential) package ensures that the requisite compiler and libraries are installed.